### PR TITLE
Double quotes parsed correctly here too.

### DIFF
--- a/_arcade-organizer.sh
+++ b/_arcade-organizer.sh
@@ -21,13 +21,13 @@ fi
 
 if [ `grep -c "ORGDIR=" "${INIFILE_FIXED}"` -gt 0 ]
    then
-      ORGDIR=`grep "ORGDIR" "${INIFILE_FIXED}" | awk -F "=" '{print$2}'`
+      ORGDIR=`grep "ORGDIR" "${INIFILE_FIXED}" | awk -F "=" '{print$2}' | sed -e 's/^ *//' -e 's/ *$//' -e 's/^ *"//' -e 's/" *$//'`
 fi 2>/dev/null 
 
 
 if [ `grep -c "MRADIR=" "${INIFILE_FIXED}"` -gt 0 ]
    then
-      MRADIR=`grep "MRADIR=" "${INIFILE_FIXED}" | awk -F "=" '{print$2}'`
+      MRADIR=`grep "MRADIR=" "${INIFILE_FIXED}" | awk -F "=" '{print$2}' | sed -e 's/^ *//' -e 's/ *$//' -e 's/^ *"//' -e 's/" *$//'`
 fi 2>/dev/null
 
 rm ${INIFILE_FIXED}


### PR DESCRIPTION
Same as in the other repo, but I forgot about this one.

Issue in the other repo: https://github.com/MAME-GETTER/MiSTer_MAME_SCRIPTS/issues/9